### PR TITLE
Daemonset now works

### DIFF
--- a/multus-dhcp/dhcp-daemonset.yml
+++ b/multus-dhcp/dhcp-daemonset.yml
@@ -49,12 +49,20 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: host
-          mountPath: /host
+        - name: socketpath
+          mountPath: /host/run/cni
+        - name: procpath
+          mountPath: /host/proc
+        - name: netnspath
+          mountPath: /host/var/run/netns
+          mountPropagation: HostToContainer
       volumes:
         - name: socketpath
           hostPath:
             path: /run/cni
-        - name: host
+        - name: procpath
           hostPath:
-            path: /
+            path: /proc
+        - name: netnspath
+          hostPath:
+            path: /run/netns


### PR DESCRIPTION
Updated the volume mounts to be a little more restrictive and secure
Added /proc since it wasn't working without it

`DHCP.Allocate: unknown FS magic`
Caused by (I beleive) not having /proc mounted within the pod