### PR TITLE
Fix Calico example manifests to be compatible with newer Kubernetes releases

### DIFF
--- a/multus-calico/calico-daemonset.yml
+++ b/multus-calico/calico-daemonset.yml
@@ -388,7 +388,7 @@ subjects:
   namespace: kube-system
 ---
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system
@@ -398,6 +398,7 @@ spec:
   selector:
     matchLabels:
       k8s-app: calico-node
+      tier: node
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -406,6 +407,7 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+        tier: node
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
@@ -586,7 +588,7 @@ metadata:
   name: calico-node
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-kube-controllers
@@ -599,6 +601,9 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
   template:
     metadata:
       name: calico-kube-controllers

--- a/multus-calico/multus-daemonset.yml
+++ b/multus-calico/multus-daemonset.yml
@@ -109,7 +109,7 @@ data:
       "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-amd64
@@ -118,6 +118,10 @@ metadata:
     tier: node
     app: multus
 spec:
+  selector:
+    matchLabels:
+      app: multus
+      tier: node
   updateStrategy:
     type: RollingUpdate
   template:


### PR DESCRIPTION
A few minor updates to the Calico manifests to make them work with newer Kubernetes versions. These have been tested on Kubernetes 1.19. See https://github.com/k8snetworkplumbingwg/reference-deployment/issues/2