### PR TITLE
Fixed a bug where script returned to main code after starting cluster, and updated multus-daemonset.yaml

### DIFF
--- a/multus-whereabouts/cluster-config.yml
+++ b/multus-whereabouts/cluster-config.yml
@@ -4,8 +4,6 @@ nodes:
   - role: control-plane
   - role: worker
   - role: worker
-  - role: worker
-  - role: worker
 # Note: uncomment if you install cni plugin by yourself
 #networking:
 #  disableDefaultCNI: true

--- a/multus-whereabouts/kind-multus-whereabouts.sh
+++ b/multus-whereabouts/kind-multus-whereabouts.sh
@@ -26,6 +26,8 @@ EOF
 
   # install macvlan
   kubectl apply -f cni-install.yml
+
+  exit 0
 }
 
 

--- a/multus-whereabouts/multus-daemonset.yml
+++ b/multus-whereabouts/multus-daemonset.yml
@@ -144,16 +144,16 @@ spec:
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot
+        image: ghcr.io/k8snetworkplumbingwg/multus-cni:thick
         command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
         args:
-        - "-multus-conf-file=auto"
-        - "-cni-version=0.3.1"
-        - "-cni-config-dir=/host/etc/cni/net.d"
-        - "-multus-autoconfig-dir=/host/etc/cni/net.d"
-        - "-multus-log-to-stderr=true"
-        - "-multus-log-level=debug"
-        - "-multus-log-file=/tmp/multus.log"
+        - "--multus-conf-file=auto"
+        - "--cni-version=0.3.1"
+        - "--cni-config-dir=/host/etc/cni/net.d"
+        - "--multus-autoconfig-dir=/host/etc/cni/net.d"
+        - "--multus-log-to-stderr=true"
+        - "--multus-log-level=debug"
+        - "--multus-log-file=/var/log/multus.log"
         resources:
           requests:
             cpu: "100m"
@@ -204,73 +204,6 @@ spec:
           - name: cni
             mountPath: /host/etc/cni/net.d
             mountPropagation: Bidirectional
-      volumes:
-        - name: cni
-          hostPath:
-            path: /etc/cni/net.d
-        - name: cnibin
-          hostPath:
-            path: /opt/cni/bin
-        - name: multus-cfg
-          configMap:
-            name: multus-cni-config
-            items:
-            - key: cni-conf.json
-              path: 70-multus.conf
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: kube-multus-ds-ppc64le
-  namespace: kube-system
-  labels:
-    tier: node
-    app: multus
-    name: multus
-spec:
-  selector:
-    matchLabels:
-      name: multus
-  updateStrategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        tier: node
-        app: multus
-        name: multus
-    spec:
-      hostNetwork: true
-      nodeSelector:
-        kubernetes.io/arch: ppc64le
-      tolerations:
-      - operator: Exists
-        effect: NoSchedule
-      serviceAccountName: multus
-      containers:
-      - name: kube-multus
-        # ppc64le support requires multus:latest for now. support 3.3 or later.
-        image: nfvpe/multus:latest-ppc64le
-        command: ["/entrypoint.sh"]
-        args:
-        - "--multus-conf-file=auto"
-        - "--cni-version=0.3.1"
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "90Mi"
-          limits:
-            cpu: "100m"
-            memory: "90Mi"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: cni
-          mountPath: /host/etc/cni/net.d
-        - name: cnibin
-          mountPath: /host/opt/cni/bin
-        - name: multus-cfg
-          mountPath: /tmp/multus-conf
       volumes:
         - name: cni
           hostPath:


### PR DESCRIPTION
Not providing an argument caused the default case to execute, but then the script would return to non-default cases. Adding "exit 0" after the cluster's creation avoids this and logically makes sense.

Also updated multus-daemonset.yaml to more closely match that of upstream multus.
